### PR TITLE
[fix] only allow a single once('exec') listener in callback case

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,11 +87,12 @@ Sequest.prototype.onConnectionReady = function () {
         }
         cb(e, stdout, o)
       })
+    } else {
+      this.once('exec', function (e) {
+        if (e) self.emit('error', e)
+        else self.emit('end')
+      })
     }
-    this.once('exec', function (e) {
-      if (e) self.emit('error', e)
-      else self.emit('end')
-    })
   } else if (this.opts.continuous) {
     if (this.pending) this.__write.apply(this, this.pending)
   }


### PR DESCRIPTION
Prevents possible duplicate ('exec') events from being handled when a callback is given.
