### PR TITLE
[fix] dont pipe to bufferstream when using cb

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,8 +115,10 @@ Sequest.prototype.__write = function (chunk, encoding, cb) {
         return cb(e)
       }
       self._pipeDests(stream)
-
-      stream.pipe(self.bufferStream, {end:false})
+      
+      // Don't buffer data that is not consumed when we are handling with callback interface
+      if (!self.cb) stream.pipe(self.bufferStream, {end:false})
+      
       var signal
         , code
         ;


### PR DESCRIPTION
Since streams inherently buffer internally, even a PassThrough stream will buffer on the writeable side of it as it passes it through to be consumed. Since we won't be consuming this bufferStream in anyway in this case, lets avoid keeping that data around in memory.
