### PR TITLE
[dist] Update all dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
   "description": "Simplified API for SSH and SFTP similar to request.",
   "main": "index.js",
   "dependencies": {
-    "bl": "^0.8.0",
-    "once": "^1.3.0",
-    "ssh2": "^0.3.0"
+    "bl": "^0.9.4",
+    "once": "^1.3.2",
+    "ssh2": "^0.4.8"
   },
   "devDependencies": {
-    "rimraf": "^2.2.8",
-    "tape": "^2.13.2"
+    "rimraf": "^2.3.3",
+    "tape": "^4.0.0"
   },
   "scripts": {
     "test": "tape test/*.js"


### PR DESCRIPTION
Older version of ssh2 seems to leak when `exec`ing many commands over one connection, reporting "possible EventEmitter memory leak detected. 11 close listeners added"

New version of ssh2 does not seem to have this issue. 

Updated all other dependencies while I was at it. Tests pass. Works in my app.

```
(node) warning: possible EventEmitter memory leak detected. 11 close listeners added. Use emitter.setMaxListeners() to increase limit.
Trace
    at Connection.addListener (events.js:236:17)
    at Connection.once (events.js:262:8)
    at new ChannelStream (/Users/timoxley/Projects/rvagg/webred/red/lib/remote/node_modules/sequest/node_modules/ssh2/lib/Channel.js:580:17)
    at /Users/timoxley/Projects/rvagg/webred/red/lib/remote/node_modules/sequest/node_modules/ssh2/lib/Channel.js:360:20
    at Parser.<anonymous> (/Users/timoxley/Projects/rvagg/webred/red/lib/remote/node_modules/sequest/node_modules/ssh2/lib/Channel.js:142:30)
    at emitNone (events.js:67:13)
    at Parser.emit (events.js:163:7)
    at Parser.parsePacket (/Users/timoxley/Projects/rvagg/webred/red/lib/remote/node_modules/sequest/node_modules/ssh2/lib/Parser.js:632:12)
    at Parser.execute (/Users/timoxley/Projects/rvagg/webred/red/lib/remote/node_modules/sequest/node_modules/ssh2/lib/Parser.js:249:14)
    at Socket.<anonymous> (/Users/timoxley/Projects/rvagg/webred/red/lib/remote/node_modules/sequest/node_modules/ssh2/lib/Connection.js:536:18)
    at emitOne (events.js:77:13)
    at Socket.emit (events.js:166:7)
    at readableAddChunk (_stream_readable.js:145:16)
    at Socket.Readable.push (_stream_readable.js:109:10)
    at TCP.onread (net.js:508:20)
```