### PR TITLE
Ensure data is in buffers before exec. Exec on 'end' instead of 'close'.

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,7 +159,7 @@ Sequest.prototype.__write = function (chunk, encoding, cb) {
           signal = _signal
           code = _code
         })
-        stream.on('close', function () {
+        stream.on('end', function () {
           self.emit('exec', e, cmd, code, signal, stdout.toString(), stderr.toString())
           if (self.opts.command && !self.leaveOpen) self.connection.end()
           cb()
@@ -177,7 +177,7 @@ Sequest.prototype.__write = function (chunk, encoding, cb) {
             return self.emit('error', new Error('Exit code non-zero, '+code))
           }
         })
-        stream.on('close', function () {
+        stream.on('end', function () {
           self.emit('exec', e, cmd, code, signal)
           if (!code) cb()
         })


### PR DESCRIPTION
Was getting seemingly totally empty responses from sequest.exec i.e. no stdout, no stderr. 

Appears that the `close` event was being fired before the data had been flushed into the `stdout`/`stderr` buffers. This occurred intermittently, seemed to be more likely when receiving tiny responses from server e.g. output of `whoami` or `pwd`. 

Not sure how to force such a race condition for a test, though all the existing tests pass.