### PR TITLE
Emit exec event after both process exit and stream end events

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,9 +145,6 @@ Sequest.prototype.__write = function (chunk, encoding, cb) {
 
       if (stream.stderr) stream.stderr.pipe(process.stderr)
 
-      var signal
-        , code
-        ;
       if (self.cb) {
         var stdout = bl()
           , stderr = bl()
@@ -155,11 +152,8 @@ Sequest.prototype.__write = function (chunk, encoding, cb) {
         stream.pipe(stdout)
 
         if (stream.stderr) stream.stderr.pipe(stderr)
-        stream.on('exit', function (_code, _signal) {
-          signal = _signal
-          code = _code
-        })
-        stream.on('end', function () {
+
+        onEndAndExit(stream, function(code, signal) {
           self.emit('exec', e, cmd, code, signal, stdout.toString(), stderr.toString())
           if (self.opts.command && !self.leaveOpen) self.connection.end()
           cb()
@@ -169,19 +163,38 @@ Sequest.prototype.__write = function (chunk, encoding, cb) {
           if (!self.leaveOpen) self.connection.end()
           return self.emit('error', e)
         }
-        stream.on('exit', function (_code, _signal) {
-          signal = _signal
-          code = _code
+        stream.on('exit', function (code, signal) {
           if (code) {
             if (!self.leaveOpen) self.connection.end()
             return self.emit('error', new Error('Exit code non-zero, '+code))
           }
         })
-        stream.on('end', function () {
+        onEndAndExit(stream, function(code, signal) {
           self.emit('exec', e, cmd, code, signal)
           if (!code) cb()
         })
       }
+    })
+  }
+  function onEndAndExit(stream, cb) {
+    var code
+      , signal
+      , ended = false
+      , exited = false
+      ;
+
+    stream.once('exit', function(_code, _signal) {
+      exited = true
+
+      if (ended) return cb(_code, _signal)
+
+      code = _code
+      signal = _signal
+    })
+
+    stream.once('end', function() {
+      ended = true
+      if (exited) cb(code, signal)
     })
   }
 }


### PR DESCRIPTION
Sometimes the stream `end` event may happen before the process exited. In those cases sequest exec results will contain undefined code. This patch makes sure both `exit` and `end` events happen, whichever comes first, before emitting the `exec` event.