### PR TITLE
Pass through readyTimeout and wire up 'error' event for SequestPut

### DIFF
--- a/index.js
+++ b/index.js
@@ -267,6 +267,7 @@ function SequestPut (conn, opts, path) {
   }
 
   this.connection = conn
+  this.connection.on('error', this.emit.bind(this, 'error'))
   this.opts = opts
   this.path = path
   var self = this

--- a/index.js
+++ b/index.js
@@ -267,11 +267,11 @@ function SequestPut (conn, opts, path) {
   }
 
   this.connection = conn
-  this.connection.on('error', this.emit.bind(this, 'error'))
   this.opts = opts
   this.path = path
   var self = this
   if (conn._state !== 'authenticated') {
+    this.connection.on('error', this.emit.bind(this, 'error'))
     this.connection.on('ready', this.onConnectionReady.bind(this))
   } else {
     process.nextTick(function () {

--- a/index.js
+++ b/index.js
@@ -50,6 +50,10 @@ function getConnection (str, opts) {
   	copts.password = opts.password;
   }
 
+  if(opts.readyTimeout) {
+    copts.readyTimeout = opts.readyTimeout;
+  }
+
   var conn = new Connection(copts)
 
   return conn


### PR DESCRIPTION
See #38 
- Allowed passing readyTimeout through to ssh2() when dealing with slow servers
- Wired up error when using the stream oriented get/put methods
