### PR TITLE
WIP: Update ssh2 so we can use ed25519 keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "bl": "^0.9.4",
     "once": "^1.3.2",
-    "ssh2": "^0.4.8"
+    "ssh2": "^0.8.9"
   },
   "devDependencies": {
     "rimraf": "^2.3.3",


### PR DESCRIPTION
Note: I’m unable to run the tests locally (a previous Gitea installation seems to have borked the ssh server settings).