### PR TITLE
Version bump to 0.10.1 (updated bl package)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sequest",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Simplified API for SSH and SFTP similar to request.",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Bumping the patch version to 0.10.1 from 0.10.0. 
Doing this to release a new version so that we can adopt the changes which contain the security fix.